### PR TITLE
Implement study plan day locking feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1803,6 +1803,29 @@ function App() {
         });
     };
 
+    const handleUpdateSessionTime = (planDate: string, taskId: string, sessionNumber: number, newStartTime: string, newEndTime: string) => {
+        setStudyPlans(prevPlans => {
+            return prevPlans.map(plan => {
+                if (plan.date === planDate) {
+                    return {
+                        ...plan,
+                        plannedTasks: plan.plannedTasks.map(session => {
+                            if (session.taskId === taskId && session.sessionNumber === sessionNumber) {
+                                return {
+                                    ...session,
+                                    startTime: newStartTime,
+                                    endTime: newEndTime
+                                };
+                            }
+                            return session;
+                        })
+                    };
+                }
+                return plan;
+            });
+        });
+    };
+
     // Interactive tutorial handlers
     const handleStartTutorial = () => {
         setShowInteractiveTutorial(true);
@@ -2146,6 +2169,7 @@ function App() {
                 onRedistributeMissedSessions={handleRedistributeMissedSessions}
                 onEnhancedRedistribution={handleEnhancedRedistribution}
                             onToggleDayLock={handleToggleDayLock}
+                            onUpdateSessionTime={handleUpdateSessionTime}
                         />
                     )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -463,10 +463,22 @@ function App() {
                     const result = generateNewStudyPlan(tasks, settings, fixedCommitments, studyPlans);
                     const newPlans = result.plans;
                     
-                    // Enhanced preservation logic
+                    // Enhanced preservation logic with lock support
                     newPlans.forEach(plan => {
                         const prevPlan = studyPlans.find(p => p.date === plan.date);
                         if (!prevPlan) return;
+                        
+                        // Preserve lock status
+                        plan.isLocked = prevPlan.isLocked;
+                        
+                        // If day is locked, preserve all sessions exactly as they were
+                        if (prevPlan.isLocked) {
+                            plan.plannedTasks = [...prevPlan.plannedTasks];
+                            plan.totalStudyHours = prevPlan.totalStudyHours;
+                            plan.availableHours = prevPlan.availableHours;
+                            plan.isOverloaded = prevPlan.isOverloaded;
+                            return;
+                        }
                         
                         plan.plannedTasks.forEach(session => {
                             const prevSession = prevPlan.plannedTasks.find(s => 
@@ -496,7 +508,7 @@ function App() {
                                     // Move session to the rescheduled date if different
                                     if (prevSession.originalDate !== plan.date) {
                                         const targetPlan = newPlans.find(p => p.date === prevSession.originalDate);
-                                        if (targetPlan) {
+                                        if (targetPlan && !targetPlan.isLocked) { // Only move if target day is not locked
                                             targetPlan.plannedTasks.push(session);
                                             plan.plannedTasks = plan.plannedTasks.filter(s => s !== session);
                                         }
@@ -516,12 +528,24 @@ function App() {
             const result = generateNewStudyPlan(tasks, settings, fixedCommitments, studyPlans);
             const newPlans = result.plans;
             
-            // Preserve session status from previous plan
+            // Preserve session status from previous plan and respect locked days
             newPlans.forEach(plan => {
                 const prevPlan = studyPlans.find(p => p.date === plan.date);
                 if (!prevPlan) return;
                 
-                // Preserve session status and properties
+                // Preserve lock status
+                plan.isLocked = prevPlan.isLocked;
+                
+                // If day is locked, preserve all sessions exactly as they were
+                if (prevPlan.isLocked) {
+                    plan.plannedTasks = [...prevPlan.plannedTasks];
+                    plan.totalStudyHours = prevPlan.totalStudyHours;
+                    plan.availableHours = prevPlan.availableHours;
+                    plan.isOverloaded = prevPlan.isOverloaded;
+                    return;
+                }
+                
+                // Preserve session status and properties for unlocked days
                 plan.plannedTasks.forEach(session => {
                     const prevSession = prevPlan.plannedTasks.find(s => s.taskId === session.taskId && s.sessionNumber === session.sessionNumber);
                     if (prevSession) {
@@ -1765,6 +1789,20 @@ function App() {
         });
     };
 
+    const handleToggleDayLock = (date: string, isLocked: boolean) => {
+        setStudyPlans(prevPlans => {
+            return prevPlans.map(plan => {
+                if (plan.date === date) {
+                    return {
+                        ...plan,
+                        isLocked
+                    };
+                }
+                return plan;
+            });
+        });
+    };
+
     // Interactive tutorial handlers
     const handleStartTutorial = () => {
         setShowInteractiveTutorial(true);
@@ -2107,6 +2145,7 @@ function App() {
                             onSkipMissedSession={handleSkipMissedSession}
                 onRedistributeMissedSessions={handleRedistributeMissedSessions}
                 onEnhancedRedistribution={handleEnhancedRedistribution}
+                            onToggleDayLock={handleToggleDayLock}
                         />
                     )}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export interface StudyPlan {
   totalStudyHours: number;
   availableHours: number; // How much time is actually available this day
   isOverloaded?: boolean; // Is this day too packed?
+  isLocked?: boolean; // Whether this day is locked from changes
 }
 
 export interface UserSettings {

--- a/src/utils/enhanced-scheduling.ts
+++ b/src/utils/enhanced-scheduling.ts
@@ -510,6 +510,9 @@ export class EnhancedRedistributionEngine {
     const plan = studyPlans.find(p => p.date === planDate);
     if (!plan) return false;
     
+    // Don't allow skipping sessions on locked days
+    if (plan.isLocked) return false;
+    
     const session = plan.plannedTasks.find(
       s => s.taskId === taskId && s.sessionNumber === sessionNumber
     );
@@ -669,6 +672,11 @@ export class EnhancedRedistributionEngine {
       // Get existing sessions for this day
       const targetPlan = workingPlans.find(p => p.date === targetDateStr);
       const existingSessions = targetPlan ? targetPlan.plannedTasks : [];
+      
+      // Skip locked days
+      if (targetPlan?.isLocked) {
+        continue;
+      }
       
       // Find available slot
       const slot = this.conflictChecker.findNextAvailableSlot(


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a 'lock day' feature allowing users to protect study sessions on specific days from automatic rescheduling and manual changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-31d23440-8886-4f02-8768-79b691853555">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31d23440-8886-4f02-8768-79b691853555">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>