### PR TITLE
Fix settings save unlocking locked days

### DIFF
--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -477,12 +477,15 @@ export const generateNewStudyPlan = (
     const dailyRemainingHours: { [date: string]: number } = {};
     availableDays.forEach(date => {
       dailyRemainingHours[date] = settings.dailyAvailableHours;
+      // Find existing plan to preserve isLocked property
+      const existingPlan = existingStudyPlans.find(p => p.date === date);
       studyPlans.push({
         id: `plan-${date}`,
         date,
         plannedTasks: [],
         totalStudyHours: 0,
-        availableHours: settings.dailyAvailableHours
+        availableHours: settings.dailyAvailableHours,
+        isLocked: existingPlan?.isLocked || false
       });
     });
     let evenTaskScheduledHours: { [taskId: string]: number } = {};
@@ -957,12 +960,15 @@ export const generateNewStudyPlan = (
       // Create study plans for extended days if needed
       availableDays.forEach(date => {
         if (!studyPlans.find(plan => plan.date === date)) {
+          // Find existing plan to preserve isLocked property
+          const existingPlan = existingStudyPlans.find(p => p.date === date);
           studyPlans.push({
             id: `${date}-study-plan`,
             date,
             plannedTasks: [],
             totalStudyHours: 0,
-            availableHours: settings.dailyAvailableHours
+            availableHours: settings.dailyAvailableHours,
+            isLocked: existingPlan?.isLocked || false
           });
         }
       });
@@ -1158,12 +1164,15 @@ export const generateNewStudyPlan = (
     const dailyRemainingHours: { [date: string]: number } = {};
     availableDays.forEach(date => {
       dailyRemainingHours[date] = settings.dailyAvailableHours;
+      // Find existing plan to preserve isLocked property
+      const existingPlan = existingStudyPlans.find(p => p.date === date);
       studyPlans.push({
         id: `plan-${date}`,
         date,
         plannedTasks: [],
         totalStudyHours: 0,
-        availableHours: settings.dailyAvailableHours
+        availableHours: settings.dailyAvailableHours,
+        isLocked: existingPlan?.isLocked || false
       });
     });
 
@@ -1423,12 +1432,15 @@ export const generateNewStudyPlan = (
   const dailyRemainingHours: { [date: string]: number } = {};
   availableDays.forEach(date => {
     dailyRemainingHours[date] = settings.dailyAvailableHours;
+    // Find existing plan to preserve isLocked property
+    const existingPlan = existingStudyPlans.find(p => p.date === date);
     studyPlans.push({
       id: `plan-${date}`,
       date,
       plannedTasks: [],
       totalStudyHours: 0,
-      availableHours: settings.dailyAvailableHours
+      availableHours: settings.dailyAvailableHours,
+      isLocked: existingPlan?.isLocked || false
     });
   });
 
@@ -2556,12 +2568,15 @@ export const redistributeAfterTaskDeletion = (
   const dailyRemainingHours: { [date: string]: number } = {};
   availableDays.forEach(date => {
     dailyRemainingHours[date] = settings.dailyAvailableHours;
+    // Find existing plan to preserve isLocked property
+    const existingPlan = existingStudyPlans.find(p => p.date === date);
     studyPlans.push({
       id: `plan-${date}`,
       date,
       plannedTasks: [],
       totalStudyHours: 0,
-      availableHours: settings.dailyAvailableHours
+      availableHours: settings.dailyAvailableHours,
+      isLocked: existingPlan?.isLocked || false
     });
   });
 


### PR DESCRIPTION
Preserve `isLocked` property when regenerating study plans to prevent locked days from being unlocked.

Previously, saving settings or deleting tasks would cause the study plan to be regenerated, but the `isLocked` status of individual days was not carried over, leading to all locked days becoming unlocked. This PR ensures the `isLocked` status is maintained.

---
<a href="https://cursor.com/background-agent?bcId=bc-2eacf0d9-5452-4b63-9980-cd7123d57490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2eacf0d9-5452-4b63-9980-cd7123d57490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>