### PR TITLE
Handle locked days during redistribution and saving

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -757,12 +757,24 @@ function App() {
         if (tasks.length > 0) {
             const { plans: newPlans } = generateNewStudyPlan(tasks, settings, updatedCommitments, studyPlans);
             
-            // Preserve session status from previous plan
+            // Preserve session status from previous plan and respect locked days
             newPlans.forEach(plan => {
                 const prevPlan = studyPlans.find(p => p.date === plan.date);
                 if (!prevPlan) return;
                 
-                // Preserve session status and properties
+                // Preserve lock status
+                plan.isLocked = prevPlan.isLocked;
+                
+                // If day is locked, preserve all sessions exactly as they were
+                if (prevPlan.isLocked) {
+                    plan.plannedTasks = [...prevPlan.plannedTasks];
+                    plan.totalStudyHours = prevPlan.totalStudyHours;
+                    plan.availableHours = prevPlan.availableHours;
+                    plan.isOverloaded = prevPlan.isOverloaded;
+                    return;
+                }
+                
+                // Preserve session status and properties for unlocked days
                 plan.plannedTasks.forEach(session => {
                     const prevSession = prevPlan.plannedTasks.find(s => s.taskId === session.taskId && s.sessionNumber === session.sessionNumber);
                     if (prevSession) {
@@ -836,12 +848,24 @@ function App() {
         if (tasks.length > 0) {
             const { plans: newPlans } = generateNewStudyPlan(tasks, settings, updatedCommitments, studyPlans);
             
-            // Preserve session status from previous plan
+            // Preserve session status from previous plan and respect locked days
             newPlans.forEach(plan => {
                 const prevPlan = studyPlans.find(p => p.date === plan.date);
                 if (!prevPlan) return;
                 
-                // Preserve session status and properties
+                // Preserve lock status
+                plan.isLocked = prevPlan.isLocked;
+                
+                // If day is locked, preserve all sessions exactly as they were
+                if (prevPlan.isLocked) {
+                    plan.plannedTasks = [...prevPlan.plannedTasks];
+                    plan.totalStudyHours = prevPlan.totalStudyHours;
+                    plan.availableHours = prevPlan.availableHours;
+                    plan.isOverloaded = prevPlan.isOverloaded;
+                    return;
+                }
+                
+                // Preserve session status and properties for unlocked days
                 plan.plannedTasks.forEach(session => {
                     const prevSession = prevPlan.plannedTasks.find(s => s.taskId === session.taskId && s.sessionNumber === session.sessionNumber);
                     if (prevSession) {
@@ -965,12 +989,24 @@ function App() {
         if (tasks.length > 0) {
             const { plans: newPlans } = generateNewStudyPlan(tasks, settings, updatedCommitments, studyPlans);
             
-            // Preserve session status from previous plan
+            // Preserve session status from previous plan and respect locked days
             newPlans.forEach(plan => {
                 const prevPlan = studyPlans.find(p => p.date === plan.date);
                 if (!prevPlan) return;
                 
-                // Preserve session status and properties
+                // Preserve lock status
+                plan.isLocked = prevPlan.isLocked;
+                
+                // If day is locked, preserve all sessions exactly as they were
+                if (prevPlan.isLocked) {
+                    plan.plannedTasks = [...prevPlan.plannedTasks];
+                    plan.totalStudyHours = prevPlan.totalStudyHours;
+                    plan.availableHours = prevPlan.availableHours;
+                    plan.isOverloaded = prevPlan.isOverloaded;
+                    return;
+                }
+                
+                // Preserve session status and properties for unlocked days
                 plan.plannedTasks.forEach(session => {
                     const prevSession = prevPlan.plannedTasks.find(s => s.taskId === session.taskId && s.sessionNumber === session.sessionNumber);
                     if (prevSession) {
@@ -1020,12 +1056,24 @@ function App() {
         if (tasks.length > 0) {
             const { plans: newPlans } = generateNewStudyPlan(tasks, settings, updatedCommitments, studyPlans);
             
-            // Preserve session status from previous plan
+            // Preserve session status from previous plan and respect locked days
             newPlans.forEach(plan => {
                 const prevPlan = studyPlans.find(p => p.date === plan.date);
                 if (!prevPlan) return;
                 
-                // Preserve session status and properties
+                // Preserve lock status
+                plan.isLocked = prevPlan.isLocked;
+                
+                // If day is locked, preserve all sessions exactly as they were
+                if (prevPlan.isLocked) {
+                    plan.plannedTasks = [...prevPlan.plannedTasks];
+                    plan.totalStudyHours = prevPlan.totalStudyHours;
+                    plan.availableHours = prevPlan.availableHours;
+                    plan.isOverloaded = prevPlan.isOverloaded;
+                    return;
+                }
+                
+                // Preserve session status and properties for unlocked days
                 plan.plannedTasks.forEach(session => {
                     const prevSession = prevPlan.plannedTasks.find(s => s.taskId === session.taskId && s.sessionNumber === session.sessionNumber);
                     if (prevSession) {
@@ -1172,7 +1220,7 @@ function App() {
         const cleanedPlans = studyPlans.map(plan => ({
             ...plan,
             plannedTasks: plan.plannedTasks.filter(session => session.taskId !== taskId)
-        })).filter(plan => plan.plannedTasks.length > 0); // Remove empty plans
+        })).filter(plan => plan.plannedTasks.length > 0 || plan.isLocked); // Keep locked days even if empty
         
         if (currentTask?.id === taskId) {
             setCurrentTask(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1702,12 +1702,24 @@ function App() {
         if (tasks.length > 0) {
             const { plans: newPlans } = generateNewStudyPlan(tasks, newSettings, fixedCommitments, studyPlans);
             
-            // Preserve session status from previous plan
+            // Preserve session status from previous plan and respect locked days
             newPlans.forEach(plan => {
                 const prevPlan = studyPlans.find(p => p.date === plan.date);
                 if (!prevPlan) return;
                 
-                // Preserve session status and properties
+                // Preserve lock status
+                plan.isLocked = prevPlan.isLocked;
+                
+                // If day is locked, preserve all sessions exactly as they were
+                if (prevPlan.isLocked) {
+                    plan.plannedTasks = [...prevPlan.plannedTasks];
+                    plan.totalStudyHours = prevPlan.totalStudyHours;
+                    plan.availableHours = prevPlan.availableHours;
+                    plan.isOverloaded = prevPlan.isOverloaded;
+                    return;
+                }
+                
+                // Preserve session status and properties for unlocked days
                 plan.plannedTasks.forEach(session => {
                     const prevSession = prevPlan.plannedTasks.find(s => s.taskId === session.taskId && s.sessionNumber === session.sessionNumber);
                     if (prevSession) {

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -503,9 +503,10 @@ export const generateNewStudyPlan = (
       while (remainingUnscheduledHours > 0 && redistributionRound < maxRedistributionRounds) {
         redistributionRound++;
         
-        // Find all available days within the task's deadline that have remaining capacity
+        // Find all available days within the task's deadline that have remaining capacity and are not locked
         const availableDaysForRedistribution = daysForTask.filter(date => {
-          return dailyRemainingHours[date] > 0;
+          const dayPlan = studyPlans.find(p => p.date === date);
+          return dailyRemainingHours[date] > 0 && !dayPlan?.isLocked;
         });
         
         if (availableDaysForRedistribution.length === 0) {
@@ -2606,7 +2607,8 @@ export const redistributeAfterTaskDeletion = (
       redistributionRound++;
       
       const availableDaysForRedistribution = daysForTask.filter(date => {
-        return dailyRemainingHours[date] > 0;
+        const dayPlan = studyPlans.find(p => p.date === date);
+        return dailyRemainingHours[date] > 0 && !dayPlan?.isLocked;
       });
       
       if (availableDaysForRedistribution.length === 0) {

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -725,6 +725,13 @@ export const generateNewStudyPlan = (
       for (let i = 0; i < sessionLengths.length && i < daysForTask.length; i++) {
         const date = daysForTask[i];
         let dayPlan = studyPlans.find(p => p.date === date)!;
+        
+        // Skip locked days during initial distribution
+        if (dayPlan.isLocked) {
+          unscheduledHours += sessionLengths[i];
+          continue;
+        }
+        
         let availableHours = dailyRemainingHours[date];
         const thisSessionLength = Math.min(sessionLengths[i], availableHours);
         
@@ -1240,6 +1247,12 @@ export const generateNewStudyPlan = (
           
           const date = daysForTask[dayIndex];
           const dayPlan = studyPlans.find(p => p.date === date)!;
+          
+          // Skip locked days during initial distribution
+          if (dayPlan.isLocked) {
+            continue;
+          }
+          
           const availableHours = dailyRemainingHours[date];
           const thisSessionLength = Math.min(sessionLengths[i], availableHours);
 
@@ -2729,6 +2742,13 @@ export const redistributeAfterTaskDeletion = (
     for (let i = 0; i < sessionLengths.length && i < daysForTask.length; i++) {
       const date = daysForTask[i];
       let dayPlan = studyPlans.find(p => p.date === date)!;
+      
+      // Skip locked days during initial distribution
+      if (dayPlan.isLocked) {
+        unscheduledHours += sessionLengths[i];
+        continue;
+      }
+      
       let availableHours = dailyRemainingHours[date];
       const thisSessionLength = Math.min(sessionLengths[i], availableHours);
       


### PR DESCRIPTION
Preserve locked days during settings updates and exclude them from schedule redistribution.

---
<a href="https://cursor.com/background-agent?bcId=bc-729f3a08-f5ae-4a70-a9d1-dd889eebe045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-729f3a08-f5ae-4a70-a9d1-dd889eebe045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>